### PR TITLE
Update ConfigurationWriter to remove double quotes around env variable reference

### DIFF
--- a/datalake-commons/src/main/scala/bio/ferlab/datalake/commons/config/ConfigurationWriter.scala
+++ b/datalake-commons/src/main/scala/bio/ferlab/datalake/commons/config/ConfigurationWriter.scala
@@ -25,15 +25,19 @@ object ConfigurationWriter {
 
     val content = toHocon(conf)
 
+    val contentWithEnvVariable = content
+      .replaceAll("\"\\$\\{", "\\$\\{")
+      .replaceAll("}\"", "}")
+
     log.debug(
       s"""writting configuration: $path :
-         |$content
+         |$contentWithEnvVariable
          |""".stripMargin)
 
     val file = new File(path)
     file.createNewFile()
     val pw = new PrintWriter(file)
-    pw.write(content)
+    pw.write(contentWithEnvVariable)
     pw.close()
 
   }

--- a/datalake-commons/src/test/resources/config/example.conf
+++ b/datalake-commons/src/test/resources/config/example.conf
@@ -42,7 +42,7 @@ sources=[
 ]
 sparkconf {
     "spark.conf1"=v1
-    "spark.conf2"=v2
+    "spark.conf2"=${?v2}
 }
 storages=[
     {

--- a/datalake-commons/src/test/scala/bio/ferlab/datalake/commons/config/ConfigurationWriterSpec.scala
+++ b/datalake-commons/src/test/scala/bio/ferlab/datalake/commons/config/ConfigurationWriterSpec.scala
@@ -18,7 +18,7 @@ class ConfigurationWriterSpec extends AnyFlatSpec with GivenWhenThen with Matche
     sources = List(
       DatasetConf("name_a", "a" ,"/path/a", PARQUET, OverWrite, Some(TableConf("db", "name_a")), List("id"), List(), Map("key" -> "value"), Map("key2" -> "value")),
       DatasetConf("name_b", "b" ,"/path/b", PARQUET, OverWrite, Some(TableConf("db", "name_b")), List("id"), List(), Map("key" -> "value"), Map("key2" -> "value"))),
-    sparkconf = Map("spark.conf1" -> "v1", "spark.conf2" -> "v2")
+    sparkconf = Map("spark.conf1" -> "v1", "spark.conf2" -> "${?v2}")
   )
 
   "ConfigurationWriter" should "read a conf and convert it to readable hocon configuration" in {
@@ -75,10 +75,11 @@ class ConfigurationWriterSpec extends AnyFlatSpec with GivenWhenThen with Matche
          |]
          |sparkconf {
          |    "spark.conf1"=v1
-         |    "spark.conf2"=v2
+         |    "spark.conf2"="${?v2}"
          |}
          |storages=[
          |    {
+         |        filesystem=S3
          |        id=a
          |        path="s3://a"
          |    }
@@ -96,7 +97,7 @@ class ConfigurationWriterSpec extends AnyFlatSpec with GivenWhenThen with Matche
     file.exists() shouldBe true
 
     val writtenConf: Configuration = ConfigSource.file(path).loadOrThrow[Configuration]
-    writtenConf shouldBe conf
+    writtenConf shouldBe conf.copy(sparkconf = Map("spark.conf1" -> "v1")) // Since v2 env variable does not exist.
   }
 
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.12"
+ThisBuild / version := "0.2.13"


### PR DESCRIPTION
typesafe config will always put ${...} in quotes so we have to remove these double quotes after
Here's the lib function that eventually remove quotes : 
```
static String renderStringUnquotedIfPossible(String s) {
        // this can quote unnecessarily as long as it never fails to quote when
        // necessary
        if (s.length() == 0)
            return renderJsonString(s);

        // if it starts with a hyphen or number, we have to quote
        // to ensure we end up with a string and not a number
        int first = s.codePointAt(0);
        if (Character.isDigit(first) || first == '-')
            return renderJsonString(s);

        if (s.startsWith("include") || s.startsWith("true") || s.startsWith("false")
                || s.startsWith("null") || s.contains("//"))
            return renderJsonString(s);

        // only unquote if it's pure alphanumeric
        for (int i = 0; i < s.length(); ++i) {
            char c = s.charAt(i);
            if (!(Character.isLetter(c) || Character.isDigit(c) || c == '-'))
                return renderJsonString(s);
        }

        return s;
    }
```
So it only unquotes if pure alphanumeric which is not the case for env variable substitution expression