### PR TITLE
feat: CLIN-943 - add getAlias in ESCLient

### DIFF
--- a/datalake-spark31/src/main/scala/bio/ferlab/datalake/spark3/elasticsearch/ElasticSearchClient.scala
+++ b/datalake-spark31/src/main/scala/bio/ferlab/datalake/spark3/elasticsearch/ElasticSearchClient.scala
@@ -19,6 +19,7 @@ class ElasticSearchClient(url: String, username: Option[String] = None, password
   private val indexUrl: String => String = indexName => s"$url/$indexName"
   private val templateUrl: String => String = templateName => s"$url/_index_template/$templateName"
   private val aliasesUrl: String = s"$url/_aliases"
+  private val aliasUrl: String => String = indexName => s"$url/$indexName/_alias"
   val log: Logger = LoggerFactory.getLogger(getClass.getCanonicalName)
 
   def http: CloseableHttpClient = {
@@ -91,6 +92,20 @@ class ElasticSearchClient(url: String, username: Option[String] = None, password
     val status = response.getStatusLine
     if (!status.getStatusCode.equals(200))
       throw new Exception(s"Server could not set template and replied :${status.getStatusCode + " : " + status.getReasonPhrase}")
+    http.close()
+    response
+  }
+
+  /**
+   * Get alias linked to the index or the index linked to the alias itself
+   * @param indexOrAliasName name of the index or the alias
+   * @return the http response sent by ElasticSearch
+   */
+  def getAlias(indexOrAliasName: String): HttpResponse = {
+    val response = http.execute(new HttpGet(aliasUrl(indexOrAliasName)))
+    val status = response.getStatusLine
+    if (!status.getStatusCode.equals(200))
+      throw new Exception(s"Server could not get aliases for '$indexOrAliasName' :${status.getStatusCode + " : " + status.getReasonPhrase}")
     http.close()
     response
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.30"
+ThisBuild / version := "0.2.31"


### PR DESCRIPTION
Required for clin-variant-etl new `Publish` step.

We want to know the current index usinge the alias we want to switch witht the new one.

Example:

```
GET https://search-external.qa.cqgc.hsj.rtss.qc.ca/clin_qa_variant_centric/_alias

Response:
{
    "clin_qa_green_variant_centric_re_000": {
        "aliases": {
            "clin_qa_variant_centric": {}
        }
    }
}
```