### PR TITLE
fix: CLIN-2119 Correctly separate MC in ClinVar parsing

### DIFF
--- a/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/publictables/normalized/Clinvar.scala
+++ b/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/publictables/normalized/Clinvar.scala
@@ -69,7 +69,7 @@ case class Clinvar(rc: RuntimeETLContext) extends SimpleETLP(rc) {
       )
       .withColumn("clndisdbincl", split(concat_ws("", col("clndisdbincl")), "\\|"))
       .withColumn("clndnincl", split(concat_ws("", col("clndnincl")), "\\|"))
-      .withColumn("mc", split(concat_ws("", col("mc")), "\\|"))
+      .withColumn("mc", split(concat_ws("|", col("mc")), "\\|"))
       .withColumn("inheritance", inheritance_udf(col("origin")))
       .drop("clin_sig_original", "clndn")
 


### PR DESCRIPTION
The code was wrongly concatenating elements of the array. The correct pattern was used on the other columns with similar restrictions.

This section is not currently covered by tests.

The only other line that concatenates the array without a proper separator is the following :

https://github.com/Ferlab-Ste-Justine/datalake-lib/blob/2e775d970b12cb6779030d837fa1d72a24a3254f/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/publictables/normalized/Clinvar.scala#L65

It looks like it should negatively interacts with the following line, but maybe it is need updated in place? It should probably be removed. Thoughts @jecos ?
