### PR TITLE
fix: CQDG-502 Enriched variants should left join with freqs

### DIFF
--- a/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/genomics/enriched/Variants.scala
+++ b/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/genomics/enriched/Variants.scala
@@ -205,7 +205,7 @@ object Variants {
       case Nil => df
       case _ =>
         val variantWithFreq = snv.freq(participantId = participantId, affectedStatus = affectedStatus, split = frequencies)
-        df.joinByLocus(variantWithFreq, "inner")
+        df.joinByLocus(variantWithFreq, "left")
     }
 
     def withSpliceAi(spliceai: DataFrame)(implicit spark: SparkSession): DataFrame = {


### PR DESCRIPTION
If frequencies filter out variants, we should not lose these variants.