### PR TITLE
fix: SKFP-793 fix INFO_ANN filter for multi allelic

### DIFF
--- a/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/implicits/GenomicImplicits.scala
+++ b/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/implicits/GenomicImplicits.scala
@@ -729,12 +729,11 @@ object GenomicImplicits {
     val refConcatAltList: Column = array_union(array(reference), col("alternates")) as "refConcatAltList"
     val uniqBases: Column = filter(array_distinct(transform(refConcatAltList, x => substring(x, 1, 1))), (allele: Column) => allele.notEqual("*"))
 
-    val matchingAllele: Column = when(
-      (alternate === "*").or(size(uniqBases) > 1), alternate
-    ).otherwise(
-      when(
-        length(alternate) === 1, lit("-")
-      ).otherwise(substring(alternate, 2, Int.MaxValue))
+    private val isStarOrNoCommonBases = (alternate === "*").or(size(uniqBases) > 1)
+    private val alternateWithoutFirstLetter = substring(alternate, 2, Int.MaxValue)
+
+    val matchingAllele: Column = when(isStarOrNoCommonBases, alternate).otherwise(
+      when(length(alternate) === 1, lit("-")).otherwise(alternateWithoutFirstLetter)
     ) as "matchingAllele"
 
     val annotations: Column = when(

--- a/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/implicits/GenomicImplicits.scala
+++ b/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/implicits/GenomicImplicits.scala
@@ -727,10 +727,10 @@ object GenomicImplicits {
 
     //Annotations
     val refConcatAltList: Column = array_union(array(reference), col("alternates")) as "refConcatAltList"
-    val uniqBases: Column = array_distinct(transform(refConcatAltList, x => substring(x, 1, 1)))
+    val uniqBases: Column = filter(array_distinct(transform(refConcatAltList, x => substring(x, 1, 1))), (allele: Column) => allele.notEqual("*"))
 
     val matchingAllele: Column = when(
-      (alternate === "*").or(size(uniqBases) > 2).or((size(uniqBases) === 2).and(not(array_contains(uniqBases, "*")))), alternate
+      (alternate === "*").or(size(uniqBases) > 1), alternate
     ).otherwise(
       when(
         length(alternate) === 1, lit("-")

--- a/datalake-spark3/src/test/scala/bio/ferlab/datalake/spark3/genomics/normalized/BaseConsequencesSpec.scala
+++ b/datalake-spark3/src/test/scala/bio/ferlab/datalake/spark3/genomics/normalized/BaseConsequencesSpec.scala
@@ -5,6 +5,7 @@ import bio.ferlab.datalake.testutils.models.normalized.NormalizedConsequences
 import bio.ferlab.datalake.testutils.models.raw.{InfoCSQ, RawVcf, RawVcfWithInfoAnn}
 import bio.ferlab.datalake.spark3.testutils.WithTestConfig
 import bio.ferlab.datalake.testutils.{SparkSpec, TestETLContext}
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{Column, DataFrame}
 
 import java.time.LocalDateTime
@@ -37,7 +38,7 @@ class BaseConsequencesSpec extends SparkSpec with WithTestConfig {
   it should "transform data with column INFO_ANN in vcf in expected format" in {
     val jobWithInfoAnn = new ConsequenceEtl(groupByLocus = false, annotationsColumn = annotations)
     val data = Map(
-      jobWithInfoAnn.raw_vcf -> Seq(RawVcfWithInfoAnn()).toDF()
+      jobWithInfoAnn.raw_vcf -> Seq(RawVcfWithInfoAnn()).toDF().withColumn("alternates", col("alternateAlleles"))
     )
     val results = jobWithInfoAnn.transform(data)
     val resultDf = results(jobWithInfoAnn.mainDestination.id)

--- a/datalake-spark3/src/test/scala/bio/ferlab/datalake/spark3/implicits/GenomicImplicitsSpec.scala
+++ b/datalake-spark3/src/test/scala/bio/ferlab/datalake/spark3/implicits/GenomicImplicitsSpec.scala
@@ -932,9 +932,10 @@ class GenomicImplicitsSpec extends SparkSpec {
     )
   }
 
-  it should "return the allele as is if there are more than 2 bases (means that reference and alternates don't share the same base)" in {
+  it should "return the allele as is if they are no common bases" in {
     val input = Seq(
       RawVcfWithInfoAnn(`referenceAllele` = "A", `alternateAlleles` = List("T", "*")),
+      RawVcfWithInfoAnn(`referenceAllele` = "G", `alternateAlleles` = List("GAA", "A")),
     ).toDF()
     val result = input
       .withColumn("alternates", col("alternateAlleles"))
@@ -944,19 +945,6 @@ class GenomicImplicitsSpec extends SparkSpec {
     result.as[(String, Seq[String], String)].collect() should contain theSameElementsAs Seq(
       ("A", Seq("T"), "T"),
       ("A", Seq("*"), "*"),
-    )
-  }
-
-  it should "return the allele as is if there are 2 bases but not * (means that reference and alternates don't share the same base)" in {
-    val input = Seq(
-      RawVcfWithInfoAnn(`referenceAllele` = "G", `alternateAlleles` = List("GAA", "A")),
-    ).toDF()
-    val result = input
-      .withColumn("alternates", col("alternateAlleles"))
-      .withSplitMultiAllelic
-      .withColumn("matchingAllele", matchingAllele)
-      .select("referenceAllele", "alternateAlleles", "matchingAllele")
-    result.as[(String, Seq[String], String)].collect() should contain theSameElementsAs Seq(
       ("G", Seq("GAA"), "GAA"),
       ("G", Seq("A"), "A"),
     )

--- a/datalake-spark3/src/test/scala/bio/ferlab/datalake/spark3/implicits/GenomicImplicitsSpec.scala
+++ b/datalake-spark3/src/test/scala/bio/ferlab/datalake/spark3/implicits/GenomicImplicitsSpec.scala
@@ -892,7 +892,7 @@ class GenomicImplicitsSpec extends SparkSpec {
     )
   }
 
-  "uniqBases" should "return the first character of each element of refConcatAltList without duplicates" in {
+  "uniqBases" should "return the first character of each element of refConcatAltList without duplicates and without *" in {
     val input = Seq(
       RawVcfWithInfoAnn(`referenceAllele` = "A", `alternateAlleles` = List("*")),
       RawVcfWithInfoAnn(`referenceAllele` = "A", `alternateAlleles` = List("T", "*")),
@@ -906,9 +906,9 @@ class GenomicImplicitsSpec extends SparkSpec {
       .withColumn("uniqBases", uniqBases)
       .select("referenceAllele", "alternateAlleles", "uniqBases")
     result.as[(String, Seq[String], Seq[String])].collect() should contain theSameElementsAs Seq(
-      ("A", Seq("*"), Seq("A", "*")),
-      ("A", Seq("T"), Seq("A", "T", "*")),
-      ("A", Seq("*"), Seq("A", "T", "*")),
+      ("A", Seq("*"), Seq("A")),
+      ("A", Seq("T"), Seq("A", "T")),
+      ("A", Seq("*"), Seq("A", "T")),
       ("G", Seq("GAA"), Seq("G", "A")),
       ("G", Seq("A"), Seq("G", "A")),
       ("TCC", Seq("T"), Seq("T")),


### PR DESCRIPTION
Le filtre de INFO_ANN sur un match parfait entre `INFO_ANN.Allele` et `alternateAlleles(0)` ne fonctionne pas pour plusieurs cas.

Voici l'algo utilisé maintenant 
```
def matchingAllele(ref_allele, alt_alleles, alternate):
    
   # uniq bases without *
    uniq_bases = filter(set([i[0] for i in [ref_allele] + alt_alleles]), s => s != '*')
    
    if alternate == '*' or len(uniq_bases) > 1: 
        return alternate
        
    if len(alternate) == 1:
        return '-'

    return alternate[1:] 
```

En résumé 
si l'alternate est `*` on renvoie `*`
si la reference et les alternates n'ont pas de base commune alors on renvoie alternate tel quel 
si la reference et les alternates ont une base commune et que l'alternate a une taille de 1 on renvoie `-`
si la reference et les alternates ont une base commune et que l'alternate a une taille de plus que 1 on retire la première lettre de alternate

```
matchingAllele("A", ["*"], "*") -> "*"
matchingAllele("G", ["A", "GAA"], "A") -> "A"
matchingAllele("TCC", ["T", "TA"], "T") -> "-"
matchingAllele("A", ["AT", "ATT"], "AT") -> "T"
```