### PR TITLE
feat: UNIC-1665 Add Delta table statistics utility methods

### DIFF
--- a/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/utils/DeltaUtils.scala
+++ b/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/utils/DeltaUtils.scala
@@ -2,7 +2,9 @@ package bio.ferlab.datalake.spark3.utils
 
 import bio.ferlab.datalake.commons.config.{Configuration, DatasetConf}
 import io.delta.tables.DeltaTable
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 
 import java.sql.Timestamp
 import java.time.LocalDateTime
@@ -81,6 +83,331 @@ object DeltaUtils {
     oldest.toLocalDateTime.minusHours(1).until(clock, ChronoUnit.HOURS)
   }
 
+  /**
+   * Retrieves statistics per file for the specified Delta table.
+   *
+   * @param path  Path of the Delta table
+   * @param spark Spark session
+   * @return A DataFrame with the following schema:
+   *         - `path`: Path of the file.
+   *         - `partitionValues`: Map of partition column names to their values.
+   *         - `size`: Size of the file in bytes.
+   *         - `modificationTime`: Last modification timestamp.
+   *         - `dataChange`: Indicates whether the file represents a data change.
+   *         - `tags`: Map of additional metadata tags.
+   *         - `stats`: Nested struct with:
+   *           - `numRecords`: Number of records in the file.
+   *           - `minValues`: Minimum values for columns.
+   *           - `maxValues`: Maximum values for columns.
+   *           - `nullCount`: Count of null values for columns.
+   * @example Result schema example:
+   * {{{
+   * root
+   *  |-- path: string (nullable = true)
+   *  |-- partitionValues: map (nullable = true)
+   *  |    |-- key: string
+   *  |    |-- value: string (valueContainsNull = true)
+   *  |-- size: long (nullable = false)
+   *  |-- modificationTime: long (nullable = false)
+   *  |-- dataChange: boolean (nullable = false)
+   *  |-- stats: struct (nullable = true)
+   *  |    |-- numRecords: long (nullable = true)
+   *  |    |-- minValues: struct (nullable = true)
+   *  |    |    |-- AA_ID: decimal(14,0) (nullable = true)
+   *  |    |    |-- ID: string (nullable = true)
+   *  |    |-- maxValues: struct (nullable = true)
+   *  |    |    |-- AA_ID: decimal(14,0) (nullable = true)
+   *  |    |    |-- ID: string (nullable = true)
+   *  |    |-- nullCount: struct (nullable = true)
+   *  |    |    |-- AA_ID: long (nullable = true)
+   *  |    |    |-- ID: long (nullable = true)
+   *  |-- tags: map (nullable = true)
+   *  |    |-- key: string
+   *  |    |-- value: string (valueContainsNull = true)
+   * }}}
+   */
+  def getTableStats(path: String)(implicit spark: SparkSession): DataFrame = {
+    require(DeltaTable.isDeltaTable(path), "Table must be a Delta table.")
+    val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, path)
+    snapshot.withStats
+  }
 
+  private def getStatPerPartition(stats: DataFrame, statAggregations: Column*): DataFrame = {
+    stats
+      .select(
+        explode(col("partitionValues")) as Seq("partitionColumn", "partitionValue"),
+        stats("*")
+      )
+      .groupBy("partitionColumn", "partitionValue")
+      .agg(statAggregations.head, statAggregations.tail: _*)
+  }
+
+  /**
+   * Extracts partition column names and their distinct sorted values from the Delta table's metadata.
+   *
+   * @param path  Path of the Delta table
+   * @param spark Spark session
+   * @return A DataFrame with columns:
+   *         - `partitionColumn`: Name of the partition columns.
+   *         - `values`: A sorted sequence of distinct values for the partition column.
+   * @example Result DataFrame example:
+   * {{{
+   * +---------------+-----------------------------------+
+   * |partitionColumn|values                             |
+   * +---------------+-----------------------------------+
+   * |ORIGIN         |[ORDER, PATIENT, STAY, TEST_RESULT]|
+   * |ingested_on_dte|[2024-11-26, 2024-11-27]           |
+   * +---------------+-----------------------------------+
+   * }}}
+   */
+  def getPartitionValues(path: String)(implicit spark: SparkSession): DataFrame = {
+    import spark.implicits._
+
+    getTableStats(path)
+      .select(explode($"partitionValues") as Seq("partitionColumn", "value"))
+      .groupBy("partitionColumn")
+      .agg(array_sort(collect_set("value")) as "values")
+  }
+
+  /**
+   * Computes the total number of records in a Delta table using the table's metadata.
+   *
+   * @param path  Path of the Delta table
+   * @param spark Spark session
+   * @return The total number of records in the table.
+   */
+  def getNumRecords(path: String)(implicit spark: SparkSession): Long = {
+    import spark.implicits._
+
+    getTableStats(path)
+      .select(sum("stats.numRecords"))
+      .as[Long]
+      .head()
+  }
+
+  /**
+   * Computes the total number of records for each partition value in a Delta table using the table's metadata.
+   *
+   * @param path  Path of the Delta table
+   * @param spark Spark session
+   * @return A DataFrame with columns:
+   *         - `partitionColumn`: Name of the partition column.
+   *         - `partitionValue`: Value of the partition.
+   *         - `numRecords`: Total number of records for the partition value.
+   * @example Result DataFrame example:
+   * {{{
+   * +---------------+--------------+----------+
+   * |partitionColumn|partitionValue|numRecords|
+   * +---------------+--------------+----------+
+   * |ORIGIN         |ORDER         |68636088  |
+   * |ORIGIN         |TEST_RESULT   |22787146  |
+   * |ORIGIN         |PATIENT       |104806    |
+   * |ORIGIN         |STAY          |2024526   |
+   * |ingested_on_dte|2024-11-26    |46776282  |
+   * |ingested_on_dte|2024-11-27    |46776284  |
+   * +---------------+--------------+----------+
+   * }}}
+   */
+  def getNumRecordsPerPartition(path: String)(implicit spark: SparkSession): DataFrame = {
+    val numRecords = sum("stats.numRecords") as "numRecords"
+    getStatPerPartition(getTableStats(path), numRecords)
+  }
+
+  /**
+   * Computes the minimum value for each non-partition column in a Delta table using the table's metadata.
+   *
+   * @param path  Path of the Delta table
+   * @param spark Spark session
+   * @return A Map where:
+   *         - Keys are column names.
+   *         - Values are the minimum values observed in the corresponding columns.
+   * @example Example result:
+   * {{{
+   * Map(
+   *   "ID" -> 1,
+   *   "UPDATE_DATE" -> 1900-01-01,
+   * )
+   * }}}
+   */
+  def getMinValues(path: String)(implicit spark: SparkSession): Map[String, Any] = {
+    val statsDf = getTableStats(path).select("stats.minValues.*")
+    val columnNames = statsDf.columns
+    val minValues = columnNames.map(c => min(c) as c)
+
+    statsDf
+      .select(minValues: _*)
+      .head()
+      .getValuesMap[Any](columnNames)
+  }
+
+  /**
+   * Computes the minimum value for each column for each partition value in a Delta table using the table's metadata.
+   *
+   * @param path  Path of the Delta table
+   * @param spark Spark session
+   * @return A DataFrame with columns:
+   *         - `partitionColumn`: Name of the partition column.
+   *         - `partitionValue`: Value of the partition.
+   *         - Each column in the Delta table: The minimum value for each column.
+   * @example For the given Delta table:
+   * {{{
+   * +----------+---------+-----------+--------+-------------------+
+   * | AA_ID    | ID      | UPDATE_DATE| ORIGIN | ingested_on_dte  |
+   * +----------+---------+-----------+--------+-------------------+
+   * | 10001    | 'ABC123'| 2024-01-01 | ORDER  | 2024-11-26       |
+   * | 10002    | 'XYZ456'| 2024-01-02 | ORDER  | 2024-11-27       |
+   * +----------+---------+-----------+--------+-------------------+
+   * }}}
+   *
+   *          The result DataFrame would look like:
+   * {{{
+   * +---------------+--------------+------------+------------+------------+
+   * |partitionColumn|partitionValue|AA_ID       |ID          |UPDATE_DATE |
+   * +---------------+--------------+------------+------------+------------+
+   * |ORIGIN         |ORDER         |10001       |'ABC123'    |2024-01-01  |
+   * |ingested_on_dte|2024-11-26    |10001       |'ABC123'    |2024-01-01  |
+   * |ingested_on_dte|2024-11-27    |10002       |'XYZ456'    |2024-01-02  |
+   * +---------------+--------------+------------+------------+------------+
+   * }}}
+   */
+  def getMinValuesPerPartition(path: String)(implicit spark: SparkSession): DataFrame = {
+    val statsDf = getTableStats(path)
+    val columnNames = statsDf.select("stats.minValues.*").columns
+    val minValues = columnNames.map(c => min(s"stats.minValues.$c") as c)
+
+    getStatPerPartition(statsDf, minValues: _*)
+  }
+
+  /**
+   * Computes the maximum value for each non-partition column in a Delta table using the table's metadata.
+   *
+   * @param path  Path of the Delta table
+   * @param spark Spark session
+   * @return A Map where:
+   *         - Keys are column names.
+   *         - Values are the maximum values observed in the corresponding columns.
+   * @example Example result:
+   * {{{
+   * Map(
+   *   "ID" -> 9999,
+   *   "UPDATE_DATE" -> 2024-01-01,
+   * )
+   * }}}
+   */
+  def getMaxValues(path: String)(implicit spark: SparkSession): Map[String, Any] = {
+    val statsDf = getTableStats(path).select("stats.maxValues.*")
+    val columnNames = statsDf.columns
+    val maxValues = columnNames.map(c => max(c) as c)
+
+    statsDf
+      .select(maxValues: _*)
+      .head()
+      .getValuesMap[Any](columnNames)
+  }
+
+  /**
+   * Computes the maximum value for each column for each partition value in a Delta table using the table's metadata.
+   *
+   * @param path  Path of the Delta table
+   * @param spark Spark session
+   * @return A DataFrame with columns:
+   *         - `partitionColumn`: Name of the partition column.
+   *         - `partitionValue`: Value of the partition.
+   *         - Each column in the Delta table: The maximum value for each column.
+   * @example For the given Delta table:
+   * {{{
+   * +----------+---------+-----------+--------+-------------------+
+   * | AA_ID    | ID      | UPDATE_DATE| ORIGIN | ingested_on_dte  |
+   * +----------+---------+-----------+--------+-------------------+
+   * | 10001    | 'ABC123'| 2024-01-01 | ORDER  | 2024-11-26       |
+   * | 10002    | 'XYZ456'| 2024-01-02 | ORDER  | 2024-11-27       |
+   * +----------+---------+-----------+--------+-------------------+
+   * }}}
+   *
+   *          The result DataFrame would look like:
+   * {{{
+   * +---------------+--------------+------------+------------+------------+
+   * |partitionColumn|partitionValue|AA_ID       |ID          |UPDATE_DATE |
+   * +---------------+--------------+------------+------------+------------+
+   * |ORIGIN         |ORDER         |10002       |'XYZ456'    |2024-01-02  |
+   * |ingested_on_dte|2024-11-26    |10001       |'ABC123'    |2024-01-01  |
+   * |ingested_on_dte|2024-11-27    |10002       |'XYZ456'    |2024-01-02  |
+   * +---------------+--------------+------------+------------+------------+
+   * }}}
+   */
+  def getMaxValuesPerPartition(path: String)(implicit spark: SparkSession): DataFrame = {
+
+    val statsDf = getTableStats(path)
+    val columnNames = statsDf.select("stats.maxValues.*").columns
+    val maxValues = columnNames.map(c => max(s"stats.maxValues.$c") as c)
+
+    getStatPerPartition(statsDf, maxValues: _*)
+  }
+
+  /**
+   * Computes the total number of nulls for each non-partition column in a Delta table using the table's metadata.
+   *
+   * @param path  Path of the Delta table
+   * @param spark Spark session
+   * @return A Map where:
+   *         - Keys are column names.
+   *         - Values are the number of nulls observed in the corresponding columns.
+   * @example Example result:
+   * {{{
+   * Map(
+   *   "ID" -> 0,
+   *   "UPDATE_DATE" -> 256,
+   * )
+   * }}}
+   */
+  def getNullCounts(path: String)(implicit spark: SparkSession): Map[String, Long] = {
+    val statsDf = getTableStats(path).select("stats.nullCount.*")
+    val columnNames = statsDf.columns
+    val nullCounts = columnNames.map(c => sum(c) as c)
+
+    statsDf
+      .select(nullCounts: _*)
+      .head()
+      .getValuesMap[Long](columnNames)
+  }
+
+  /**
+   * Computes the total number of nulls for each column for each partition value in a Delta table using the table's metadata.
+   *
+   * @param path  Path of the Delta table
+   * @param spark Spark session
+   * @return A DataFrame with columns:
+   *         - `partitionColumn`: Name of the partition column.
+   *         - `partitionValue`: Value of the partition.
+   *         - Each column in the Delta table: The number of nulls for each column.
+   * @example For the given Delta table:
+   * {{{
+   * +----------+---------+------------+--------+------------------+
+   * | AA_ID    | ID      | UPDATE_DATE| ORIGIN | ingested_on_dte  |
+   * +----------+---------+------------+--------+------------------+
+   * | 10001    | 'ABC123'| null       | ORDER  | 2024-11-26       |
+   * | 10002    | null    | null       | ORDER  | 2024-11-27       |
+   * +----------+---------+------------+--------+------------------+
+   * }}}
+   *
+   *          The result DataFrame would look like:
+   * {{{
+   * +---------------+--------------+-----+---+------------+
+   * |partitionColumn|partitionValue|AA_ID|ID |UPDATE_DATE |
+   * +---------------+--------------+-----+---+------------+
+   * |ORIGIN         |ORDER         |0    |1  |2           |
+   * |ingested_on_dte|2024-11-26    |0    |0  |1           |
+   * |ingested_on_dte|2024-11-27    |0    |1  |1           |
+   * +---------------+--------------+-----+---+------------+
+   * }}}
+   */
+  def getNullCountsPerPartition(path: String)(implicit spark: SparkSession): DataFrame = {
+
+    val statsDf = getTableStats(path)
+    val columnNames = statsDf.select("stats.nullCount.*").columns
+    val nullCounts = columnNames.map(c => sum(s"stats.nullCount.$c") as c)
+
+    getStatPerPartition(statsDf, nullCounts: _*)
+  }
 }
 

--- a/datalake-spark3/src/test/scala/bio/ferlab/datalake/spark3/utils/DeltaUtilsSpec.scala
+++ b/datalake-spark3/src/test/scala/bio/ferlab/datalake/spark3/utils/DeltaUtilsSpec.scala
@@ -1,12 +1,48 @@
 package bio.ferlab.datalake.spark3.utils
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
+import bio.ferlab.datalake.commons.config.Format.DELTA
+import bio.ferlab.datalake.commons.config.LoadType.OverWritePartition
+import bio.ferlab.datalake.commons.config.{DatalakeConf, DatasetConf, SimpleConfiguration, StorageConf}
+import bio.ferlab.datalake.commons.file.FileSystemType.LOCAL
+import bio.ferlab.datalake.spark3.loader.LoadResolver
+import bio.ferlab.datalake.testutils.SparkSpec
+import org.apache.commons.io.FileUtils
+import org.apache.spark.sql.DataFrame
+import org.scalatest.BeforeAndAfterAll
 
-import java.sql.Timestamp
+import java.nio.file.{Files, Path}
+import java.sql.{Date, Timestamp}
 import java.time.LocalDateTime
 
-class DeltaUtilsSpec  extends AnyFlatSpec with Matchers {
+case class TEST(id: Int, value: Option[String], cond: Boolean, date: Date)
+
+class DeltaUtilsSpec extends SparkSpec with BeforeAndAfterAll {
+
+  import spark.implicits._
+
+  val testDs: DatasetConf = DatasetConf("test_ds", "default", "/test", DELTA, OverWritePartition, partitionby = List("cond", "date"))
+
+  // Use the same temporary folder for all unit tests
+  lazy val tempPath: Path = Files.createTempDirectory("temp")
+  lazy implicit val conf: SimpleConfiguration = SimpleConfiguration(datalake = DatalakeConf(
+    storages = List(StorageConf("default", tempPath.toAbsolutePath.toString, LOCAL)),
+    sources = List(testDs)))
+
+  val testDf: DataFrame = Seq(
+    TEST(id = 1, value = Some("a"), cond = true, date = Date.valueOf("2020-01-01")),
+    TEST(id = 2, value = Some("b"), cond = false, date = Date.valueOf("2020-01-01")),
+    TEST(id = 3, value = None, cond = true, date = Date.valueOf("2020-01-02")),
+  ).toDF
+
+  override def beforeAll(): Unit = {
+    LoadResolver
+      .write(spark, conf)(testDs.format, testDs.loadtype)
+      .apply(testDs, testDf)
+  }
+
+  override def afterAll(): Unit = {
+    FileUtils.deleteDirectory(tempPath.toFile)
+  }
 
   "getRetentionHours" should "return the difference between now and the oldest timestamp - 1 hour" in {
 
@@ -24,4 +60,132 @@ class DeltaUtilsSpec  extends AnyFlatSpec with Matchers {
 
   }
 
+  "getPartitionValues" should "return a DataFrame with distinct partition values in a Delta table" in {
+    val result: DataFrame = DeltaUtils.getPartitionValues(testDs.location)
+
+    result
+      .as[(String, List[String])]
+      .collect() should contain theSameElementsAs Seq(
+      ("cond", List("false", "true")),
+      ("date", List("2020-01-01", "2020-01-02")),
+    )
+  }
+
+  "getNumRecords" should "return the total number of records in a Delta table" in {
+    val result: Long = DeltaUtils.getNumRecords(testDs.location)
+
+    result shouldBe 3
+  }
+
+  "getNumRecordsPerPartition" should "return the total number of records for each partition in a Delta table" in {
+    val result: DataFrame = DeltaUtils.getNumRecordsPerPartition(testDs.location)
+
+    result
+      .as[(String, String, Long)]
+      .collect() should contain theSameElementsAs Seq(
+      ("cond", "false", 1),
+      ("cond", "true", 2),
+      ("date", "2020-01-01", 2),
+      ("date", "2020-01-02", 1)
+    )
+  }
+
+  "getMinValues" should "return the minimum value for each non-partition column in a Delta table" in {
+    val result: Map[String, Any] = DeltaUtils.getMinValues(testDs.location)
+
+    result should contain theSameElementsAs Map(
+      "id" -> 1,
+      "value" -> "a",
+    )
+  }
+
+  "getMinValuesPerPartition" should "return the minimum value for each column for each partition value in a Delta table" in {
+    val result: DataFrame = DeltaUtils.getMinValuesPerPartition(testDs.location)
+
+    result
+      .select("partitionColumn", "partitionValue", "id")
+      .as[(String, String, Int)]
+      .collect() should contain theSameElementsAs Seq(
+      ("cond", "false", 2),
+      ("cond", "true", 1),
+      ("date", "2020-01-01", 1),
+      ("date", "2020-01-02", 3)
+    )
+
+    result
+      .select("partitionColumn", "partitionValue", "value")
+      .as[(String, String, Option[String])]
+      .collect() should contain theSameElementsAs Seq(
+      ("cond", "false", Some("b")),
+      ("cond", "true", Some("a")),
+      ("date", "2020-01-01", Some("a")),
+      ("date", "2020-01-02", None)
+    )
+  }
+
+  "getMaxValues" should "return the maximum value for each non-partition column in a Delta table" in {
+    val result: Map[String, Any] = DeltaUtils.getMaxValues(testDs.location)
+
+    result should contain theSameElementsAs Map(
+      "id" -> 3,
+      "value" -> "b",
+    )
+  }
+
+  "getMaxValuesPerPartition" should "return the maximum value for each column for each partition value in a Delta table" in {
+    val result: DataFrame = DeltaUtils.getMaxValuesPerPartition(testDs.location)
+
+    result
+      .select("partitionColumn", "partitionValue", "id")
+      .as[(String, String, Int)]
+      .collect() should contain theSameElementsAs Seq(
+      ("cond", "false", 2),
+      ("cond", "true", 3),
+      ("date", "2020-01-01", 2),
+      ("date", "2020-01-02", 3)
+    )
+
+    result
+      .select("partitionColumn", "partitionValue", "value")
+      .as[(String, String, Option[String])]
+      .collect() should contain theSameElementsAs Seq(
+      ("cond", "false", Some("b")),
+      ("cond", "true", Some("a")),
+      ("date", "2020-01-01", Some("b")),
+      ("date", "2020-01-02", None)
+    )
+  }
+
+  "getNullCounts" should "return the total number of nulls for each non-partition column in a Delta table" in {
+    val result: Map[String, Long] = DeltaUtils.getNullCounts(testDs.location)
+
+    result should contain theSameElementsAs Map(
+      "id" -> 0,
+      "value" -> 1
+    )
+  }
+
+  "getNullCountsPerPartition" should "return the total number of nulls for each column for each partition value in a Delta table" in {
+    val result: DataFrame = DeltaUtils.getNullCountsPerPartition(testDs.location)
+
+    result
+      .select("partitionColumn", "partitionValue", "id")
+      .as[(String, String, Long)]
+      .collect() should contain theSameElementsAs Seq(
+      ("cond", "false", 0),
+      ("cond", "true", 0),
+      ("date", "2020-01-01", 0),
+      ("date", "2020-01-02", 0)
+    )
+
+    result
+      .select("partitionColumn", "partitionValue", "value")
+      .as[(String, String, Long)]
+      .collect() should contain theSameElementsAs Seq(
+      ("cond", "false", 0),
+      ("cond", "true", 1),
+      ("date", "2020-01-01", 0),
+      ("date", "2020-01-02", 1)
+    )
+  }
 }


### PR DESCRIPTION
## Description

Leverage the Delta Log API to fetch pre-computed statistics for Delta tables, avoiding the need to scan all table rows for the same information.

## New Methods

### Full Table Statistics
- **`getTableStats`**
- **`getNumRecords`**
- **`getMinValues`**
- **`getMaxValues`**
- **`getNullCounts`**

### Per-Partition Statistics
- **`getPartitionValues`**
- **`getNumRecordsPerPartition`**
- **`getMinValuesPerPartition`**
- **`getMaxValuesPerPartition`**
- **`getNullCountsPerPartition`**

## Key Improvements
- Eliminates full table row-scanning for statistics, significantly improving efficiency.
- Provides granular per-partition insights, enhancing data analysis capabilities.
