### PR TITLE
feat: CLIN-4246 add error handling utils

### DIFF
--- a/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/utils/ErrorHandlingUtils.scala
+++ b/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/utils/ErrorHandlingUtils.scala
@@ -1,0 +1,32 @@
+package bio.ferlab.datalake.spark3.utils
+
+import org.slf4j
+import scala.util.Try
+
+object ErrorHandlingUtils {
+
+  implicit val log: slf4j.Logger = slf4j.LoggerFactory.getLogger(getClass.getCanonicalName)
+
+  /**
+   * Throw an error if the ETL run results contain a [[Throwable]]
+   *
+   * @param runs Iterable of ETL run results
+   */
+  def runOptThrow(runs: => Iterable[Option[Throwable]]): Unit = {
+    runs.flatten.headOption.foreach(t => throw t)
+  }
+
+  /**
+   * Try a function and optionally return a [[Throwable]]
+   *
+   * @param f            function to try
+   * @param errorMessage message to log if the try fails
+   * @tparam T return type of the function f
+   * @return a throwable if the function failed
+   */
+  def optIfFailed[T](f: => T, errorMessage: => String): Option[Throwable] =
+    Try(f).failed.map { t =>
+      log.error(errorMessage, t)
+      t
+    }.toOption
+}

--- a/datalake-spark3/src/test/scala/bio/ferlab/datalake/spark3/utils/ErrorHandlingUtilsSpec.scala
+++ b/datalake-spark3/src/test/scala/bio/ferlab/datalake/spark3/utils/ErrorHandlingUtilsSpec.scala
@@ -1,0 +1,69 @@
+package bio.ferlab.datalake.spark3.utils
+
+import bio.ferlab.datalake.testutils.WithLogCapture
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ErrorHandlingUtilsSpec extends AnyFlatSpec with Matchers with WithLogCapture {
+
+  "runOptThrow" should "throw the first exception if any" in {
+    val exception1 = new RuntimeException("First error")
+    val exception2 = new RuntimeException("Second error")
+
+    val thrown = the [RuntimeException] thrownBy {
+      ErrorHandlingUtils.runOptThrow(
+        Seq(None, Some(exception1), Some(exception2))
+      )
+    }
+    thrown.getMessage should equal ("First error")
+  }
+
+  "runOptThrow" should "support a by-name parameter and throw the first exception if any" in {
+    val exception1 = new RuntimeException("First error")
+    val exception2 = new RuntimeException("Second error")
+
+    val thrown = the [RuntimeException] thrownBy {
+      ErrorHandlingUtils.runOptThrow {
+        Seq(None, Some(exception1), Some(exception2))
+      }
+    }
+    thrown.getMessage should equal ("First error")
+  }
+
+  "runOptThrow" should "not throw if no exceptions are present" in {
+    noException should be thrownBy {
+      ErrorHandlingUtils.runOptThrow(Seq(None, None))
+    }
+  }
+
+  "runOptThrow" should "do nothing if the iterable is empty" in {
+    noException should be thrownBy {
+      ErrorHandlingUtils.runOptThrow(Seq.empty)
+    }
+  }
+
+  "optIfFailed" should "return None if the function succeeds" in {
+    withLogCapture(ErrorHandlingUtils.getClass) { appender => 
+      def successfulFunction(): Int = 42
+      val result = ErrorHandlingUtils.optIfFailed(successfulFunction, "This should not be logged")
+
+      result shouldBe None
+      appender.getEvents shouldBe empty
+    }
+  }
+
+  "optIfFailed" should "return Some(Throwable) if the function fails" in {
+    withLogCapture(ErrorHandlingUtils.getClass) { appender => 
+      def failingFunction(): Int = throw new RuntimeException("Test error")
+
+      val result = ErrorHandlingUtils.optIfFailed(failingFunction, "This should be logged")
+
+      result shouldBe defined
+      result.get.getMessage shouldBe "Test error"
+      appender.getEvents.size shouldBe 1
+      appender.getEvents.head.getMessage.getFormattedMessage() shouldBe "This should be logged"
+    }
+  }
+
+
+}

--- a/datalake-test-utils/src/main/scala/bio/ferlab/datalake/testutils/WithLogCapture.scala
+++ b/datalake-test-utils/src/main/scala/bio/ferlab/datalake/testutils/WithLogCapture.scala
@@ -1,0 +1,42 @@
+package bio.ferlab.datalake.testutils
+
+import org.apache.logging.log4j.core.{LoggerContext, LogEvent}
+import org.apache.logging.log4j.core.appender.AbstractAppender
+import org.apache.logging.log4j.Level
+import org.slf4j.LoggerFactory
+import scala.collection.mutable.ListBuffer
+
+trait WithLogCapture {
+
+  def withLogCapture[T](loggerName: String)(block:  ListAppender => T): T = {
+    val appender = new ListAppender("List");
+    appender.start();
+
+    val loggerConfig = LoggerContext.getContext(false).getConfiguration().getLoggerConfig(loggerName)
+    loggerConfig.addAppender(appender, Level.ALL, null)
+
+    try { block(appender) }
+    finally {
+      loggerConfig.removeAppender("List")
+      appender.stop()
+    }
+  }
+
+  def withLogCapture[T](clazz: Class[_])(block: ListAppender => T): T = withLogCapture(clazz.getCanonicalName)(block)
+}
+
+case class ListAppender(name: String) extends AbstractAppender(name, null, null, false, null) {
+
+  private val events = ListBuffer.empty[LogEvent]
+
+  def append(event: LogEvent): Unit = {
+    events += event
+  }
+
+  def getEvents: Seq[LogEvent] = events.toSeq
+
+  override def stop(): Unit = {
+    super.stop()
+    events.clear()
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces utility functions for error handling, inspired by code from unic.

## Changes
- Error Handling Utilities: Added functions `runOptThrow` and `optIfFailed`.
- Introduced a test utility to capture and assert log output during unit tests.

## Links
- https://ferlab-crsj.atlassian.net/browse/CLIN-4246
- I need the error handling utilities introduced in this PR for another PR:  https://github.com/Ferlab-Ste-Justine/clin-variant-etl/pull/469
