### PR TITLE
fix: SKFP-1545 fix dbsnp import

### DIFF
--- a/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/publictables/normalized/DBSNP.scala
+++ b/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/publictables/normalized/DBSNP.scala
@@ -27,6 +27,7 @@ case class DBSNP(rc: RuntimeETLContext) extends SimpleETLP(rc)  {
     import spark.implicits._
     data(raw_dbsnp.id)
       .where($"contigName" like "NC_%")
+      .withColumn("alternate", explode($"alternateAlleles"))
       .withColumn("chromosome", regexp_extract($"contigName", "NC_(\\d+).(\\d+)", 1).cast("int"))
       .select(
         when($"chromosome" === 23, "X")
@@ -37,7 +38,7 @@ case class DBSNP(rc: RuntimeETLContext) extends SimpleETLP(rc)  {
         end,
         name,
         reference,
-        alternate,
+        $"alternate",
         $"contigName" as "original_contig_name"
       )
   }


### PR DESCRIPTION
DbSNP file has a column alternateAlleles that is a list and can include more than 1 element, currently we always pick the first element so we loose all the others alternates for a given line

Change the code to explode on this column to have X lines in output for X elements in alternateAlleles