### PR TITLE
feat: Support readCurrent for any partitioned dataset

### DIFF
--- a/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/implicits/DatasetConfImplicits.scala
+++ b/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/implicits/DatasetConfImplicits.scala
@@ -41,11 +41,11 @@ object DatasetConfImplicits {
     def readCurrent(implicit config: Configuration, spark: SparkSession): DataFrame = {
       val df = ds.read
       ds.loadtype match {
-        case OverWritePartition =>
-          val maxPartition = df.select(max(col(ds.partitionby.head))).collect().head.get(0)
-          df.filter(col(ds.partitionby.head) === maxPartition)
         case Scd2 =>
           df.filter(col(ds.writeoptions(IS_CURRENT_COLUMN_NAME)))
+        case _ if ds.partitionby.nonEmpty =>
+          val maxPartition = df.select(max(col(ds.partitionby.head))).collect().head.get(0)
+          df.filter(col(ds.partitionby.head) === maxPartition)
         case _ => df
       }
     }

--- a/datalake-spark3/src/test/scala/bio/ferlab/datalake/spark3/implicits/DatasetConfImplicitsSpec.scala
+++ b/datalake-spark3/src/test/scala/bio/ferlab/datalake/spark3/implicits/DatasetConfImplicitsSpec.scala
@@ -1,113 +1,110 @@
 package bio.ferlab.datalake.spark3.implicits
 
-import bio.ferlab.datalake.commons.config.Format.{CSV, DELTA}
+import bio.ferlab.datalake.commons.config.Format.DELTA
 import bio.ferlab.datalake.commons.config.LoadType.{OverWrite, OverWritePartition, Scd2}
-import bio.ferlab.datalake.commons.config.{Configuration, DatalakeConf, DatasetConf, LoadType, SimpleConfiguration, StorageConf, TableConf, WriteOptions}
+import bio.ferlab.datalake.commons.config.{Configuration, DatalakeConf, DatasetConf, SimpleConfiguration, StorageConf, TableConf, WriteOptions}
 import bio.ferlab.datalake.commons.file.FileSystemType.LOCAL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits._
-import bio.ferlab.datalake.testutils.SparkSpec
+import bio.ferlab.datalake.spark3.loader.LoadResolver
+import bio.ferlab.datalake.testutils.{CleanUpBeforeEach, SparkSpec}
+import org.apache.spark.sql.DataFrame
 
-import java.nio.file.Files
 import java.sql.Date
 import java.time.LocalDate
 
-class DatasetConfImplicitsSpec extends SparkSpec {
+class DatasetConfImplicitsSpec extends SparkSpec with CleanUpBeforeEach {
 
   val tableName = "my_table"
   val databaseName = "default"
 
   import spark.implicits._
 
-  val output: String = Files.createTempDirectory("DatasetConfImplicitsSpec").toAbsolutePath.toString
+  val overWritePartitionDs: DatasetConf = DatasetConf("ow_ds", "default", "/ow", DELTA, OverWritePartition, partitionby = List("date"))
+  val scd2Ds: DatasetConf = DatasetConf("scd2_ds", "default", "/scd2", DELTA, Scd2, writeoptions = WriteOptions.DEFAULT_OPTIONS)
+  val placeholderDs: DatasetConf = DatasetConf("placeholder_ds", "default", "/path/placeholder", DELTA, OverWrite, table = Some(TableConf("default", "placeholder_table")))
 
-  implicit val conf: Configuration = SimpleConfiguration(DatalakeConf(
-    sources = List(
-      DatasetConf("overwritepartition_table", "storageid", "path", DELTA, OverWritePartition, partitionby = List("date")),
-      DatasetConf("scd2_table", "storageid", "path2", DELTA, Scd2, writeoptions = WriteOptions.DEFAULT_OPTIONS),
-      DatasetConf("placeholder_table", "storageid", "path/placeholder", DELTA, OverWrite, table = TableConf("default", "placeholder_table"))
-    ),
-    storages = List(
-      StorageConf("storageid", output, LOCAL)
-    )
-  ))
+  lazy implicit val conf: SimpleConfiguration = SimpleConfiguration(DatalakeConf(
+    sources = List(overWritePartitionDs, scd2Ds, placeholderDs),
+    storages = List(StorageConf("default", this.getClass.getClassLoader.getResource(".").getFile, LOCAL))))
 
-  withOutputFolder("output") { output =>
-    val df =
-      Seq(("1", "2", "test"), ("3", "4", "test"))
-        .toDF("a", "b", "c")
-    df.write
-      .mode("overwrite")
-      .format("parquet")
-      .option("path", output)
-      .saveAsTable(s"$databaseName.$tableName")
+  // We only need to clean placeholderDs since it's the only one with a TableConf (and thus creates a table in the metastore).
+  // If we don't drop it from the metastore, we get a DELTA_TABLE_LOCATION_MISMATCH error.
+  override val dsToClean: List[DatasetConf] = List(placeholderDs)
+
+  val testData: DataFrame = Seq(
+    ("1", true, Date.valueOf(LocalDate.of(1900, 1, 1))),
+    ("1", false, Date.valueOf(LocalDate.of(1900, 2, 1))),
+    ("2", false, Date.valueOf(LocalDate.of(1900, 2, 1))),
+    ("1", false, Date.valueOf(LocalDate.of(1900, 3, 1))),
+    ("2", true, Date.valueOf(LocalDate.of(1900, 3, 1)))
+  ).toDF("oid", "is_current", "date")
+
+  "tableExist" should "return true if table exists in Spark catalog" in {
+    withOutputFolder("root") { root =>
+      val updatedConf: Configuration = updateConfStorages(conf, root)
+
+      // We use placeHolderDs since it's the only test ds with TableConf
+      LoadResolver
+        .write(spark, updatedConf)(placeholderDs.format, placeholderDs.loadtype)
+        .apply(placeholderDs, testData)
+
+      placeholderDs.tableExist shouldBe true
+      overWritePartitionDs.tableExist shouldBe false
+      scd2Ds.tableExist shouldBe false
+    }
   }
 
-  "tableExist" should "return true if table exist in spark catalog" in {
-    val dsConf = DatasetConf("id", "storageid", "path", CSV, LoadType.Read, table = Some(TableConf(databaseName, tableName)))
-    val dsConf2 = dsConf.copy(table = Some(TableConf(databaseName, "another_table")))
-    val dsConf3 = dsConf.copy(table = Some(TableConf("another_schema", tableName)))
-    assert(dsConf.tableExist)
-    assert(!dsConf2.tableExist)
-    assert(!dsConf3.tableExist)
+  "readCurrent" should "return the last partition for a partitioned dataset" in {
+    withOutputFolder("root") { root =>
+      val updatedConf: Configuration = updateConfStorages(conf, root)
 
+      LoadResolver
+        .write(spark, updatedConf)(overWritePartitionDs.format, overWritePartitionDs.loadtype)
+        .apply(overWritePartitionDs, testData)
+
+      overWritePartitionDs
+        .readCurrent(updatedConf, spark)
+        .drop("is_current") // Not relevant for this test
+        .as[(String, Date)]
+        .collect() should contain theSameElementsAs Seq(
+        ("1", Date.valueOf(LocalDate.of(1900, 3, 1))),
+        ("2", Date.valueOf(LocalDate.of(1900, 3, 1)))
+      )
+    }
   }
 
+  it should "return current data for an scd2 table" in {
+    withOutputFolder("root") { root =>
+      val updatedConf: Configuration = updateConfStorages(conf, root)
 
-  "readCurrent" should "return last partition" in {
-    val ds = conf.getDataset("overwritepartition_table")
-    Seq(
-      ("1", Date.valueOf(LocalDate.of(1900, 1, 1))),
-      ("1", Date.valueOf(LocalDate.of(1900, 2, 1))),
-      ("2", Date.valueOf(LocalDate.of(1900, 2, 1))),
-      ("1", Date.valueOf(LocalDate.of(1900, 3, 1))),
-      ("2", Date.valueOf(LocalDate.of(1900, 3, 1)))
-    ).toDF("id", "date")
-      .write
-      .mode("overwrite")
-      .format("delta").save(ds.location)
+      LoadResolver
+        .write(spark, updatedConf)(scd2Ds.format, OverWrite) // To avoid SCD2 logic during write
+        .apply(scd2Ds, testData)
 
-    ds.readCurrent.as[(String, Date)].collect() should contain theSameElementsAs Seq(
-      ("1", Date.valueOf(LocalDate.of(1900, 3, 1))),
-      ("2", Date.valueOf(LocalDate.of(1900, 3, 1)))
-    )
-  }
-
-  "readCurrent" should "return current data in scd2 table" in {
-    val ds = conf.getDataset("scd2_table")
-    Seq(
-      ("1", true, Date.valueOf(LocalDate.of(1900, 1, 1))),
-      ("1", false, Date.valueOf(LocalDate.of(1900, 2, 1))),
-      ("2", false, Date.valueOf(LocalDate.of(1900, 2, 1))),
-      ("1", false, Date.valueOf(LocalDate.of(1900, 3, 1))),
-      ("2", true, Date.valueOf(LocalDate.of(1900, 3, 1)))
-    ).toDF("id", "is_current", "date")
-      .write
-      .mode("overwrite")
-      .format("delta").save(ds.location)
-
-    ds.readCurrent.as[(String, Boolean, Date)].collect() should contain theSameElementsAs Seq(
-      ("1", true, Date.valueOf(LocalDate.of(1900, 1, 1))),
-      ("2", true, Date.valueOf(LocalDate.of(1900, 3, 1)))
-    )
+      scd2Ds
+        .readCurrent(updatedConf, spark)
+        .as[(String, Boolean, Date)]
+        .collect() should contain theSameElementsAs Seq(
+        ("1", true, Date.valueOf(LocalDate.of(1900, 1, 1))),
+        ("2", true, Date.valueOf(LocalDate.of(1900, 3, 1)))
+      )
+    }
   }
 
   "replaceTableName" should "clean invalid characters from table name" in {
     val invalidReplacement = "new.$name.1"
     val validReplacement = "new__name_1"
 
-    val datasetConf = conf.getDataset("placeholder_table")
-      .replaceTableName("placeholder", invalidReplacement, clean = true)
+    val updatedDs = placeholderDs.replaceTableName("placeholder", invalidReplacement, clean = true)
 
-    datasetConf.table.get.name shouldBe s"${validReplacement}_table"
+    updatedDs.table.get.name shouldBe s"${validReplacement}_table"
   }
 
   "replacePlaceholders" should "override a DatasetConf path and tableName" in {
-    val ds = conf.getDataset("placeholder_table")
     val customVal = "custom"
-    val datasetConf = ds.replacePlaceholders("placeholder", customVal)
+    val updatedDs = placeholderDs.replacePlaceholders("placeholder", customVal)
 
-    datasetConf.path shouldBe s"path/$customVal"
-    datasetConf.table.get.name shouldBe s"${customVal}_table"
+    updatedDs.path shouldBe s"/path/$customVal"
+    updatedDs.table.get.name shouldBe s"${customVal}_table"
   }
-
 }


### PR DESCRIPTION
## Summary
- Generalize `DatasetConfImplicits.readCurrent` so any `DatasetConf` with a non-empty `partitionby` returns its latest partition — not only those with `OverWritePartition` load type
- Remove duplicate max-partition logic by collapsing the `OverWritePartition` and generic partitioned branches into a single guard
- Refactor `DatasetConfImplicitsSpec` to use `CleanUpBeforeEach` and shared `DatasetConf` fixtures for clarity

## Test plan
- [x] `sbt "datalake-spark3/testOnly *DatasetConfImplicitsSpec"` passes
- [ ] Verify `readCurrent` on a partitioned dataset with a non-`OverWritePartition` load type returns only the latest partition
- [ ] Verify SCD2 and non-partitioned behavior are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)