### PR TITLE
:bug: fix: Skip ES write and refresh when DataFrame is empty

### DIFF
--- a/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/elasticsearch/Indexer.scala
+++ b/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/elasticsearch/Indexer.scala
@@ -53,23 +53,30 @@ class Indexer(jobType: String,
 
     if (jobType == "index") setupIndex(currentIndex, templateFilePath)
 
-    withReplicasDisabled(currentIndex, disableReplicas) {
-      df.saveToEs(s"$currentIndex/_doc", esConfig)
-      log.info(s"Refreshing index [$currentIndex]")
-      esClient.refreshIndex(currentIndex)
-    }
+    // Empty df is a no-op on ES: skip write, replica toggling, refresh, and force merge.
+    // Without this guard, refreshIndex (and createIndex inside disableReplicas) would target
+    // an index that saveToEs never created via es.index.auto.create.
+    if (df.isEmpty) {
+      log.info(s"DataFrame is empty for index [$currentIndex] — skipping ES write, refresh, and force merge")
+    } else {
+      withReplicasDisabled(currentIndex, disableReplicas) {
+        df.saveToEs(s"$currentIndex/_doc", esConfig)
+        log.info(s"Refreshing index [$currentIndex]")
+        esClient.refreshIndex(currentIndex)
+      }
 
-    // Force merge runs AFTER replicas are restored AND STARTED so it operates on every shard copy.
-    // waitForGreen blocks until all replicas finish peer-recovery — otherwise force merge races with
-    // recovery and only merges primaries, leaving replicas fragmented (10+ segments each).
-    // If write failed above, the exception propagates and we never reach this line — correct, no point merging a failed index.
-    if (forceMerge) {
-      log.info(s"Waiting for index [$currentIndex] to reach green status before force merge")
-      if (esClient.waitForGreen(currentIndex)) {
-        log.info(s"Triggering async force merge for index [$currentIndex] (runs in background on ES)")
-        esClient.forceMergeIndex(currentIndex, maxNumSegments = 1)
-      } else {
-        log.warn(s"Index [$currentIndex] did not reach green status — skipping force merge to avoid merging only primaries")
+      // Force merge runs AFTER replicas are restored AND STARTED so it operates on every shard copy.
+      // waitForGreen blocks until all replicas finish peer-recovery — otherwise force merge races with
+      // recovery and only merges primaries, leaving replicas fragmented (10+ segments each).
+      // If write failed above, the exception propagates and we never reach this line — correct, no point merging a failed index.
+      if (forceMerge) {
+        log.info(s"Waiting for index [$currentIndex] to reach green status before force merge")
+        if (esClient.waitForGreen(currentIndex)) {
+          log.info(s"Triggering async force merge for index [$currentIndex] (runs in background on ES)")
+          esClient.forceMergeIndex(currentIndex, maxNumSegments = 1)
+        } else {
+          log.warn(s"Index [$currentIndex] did not reach green status — skipping force merge to avoid merging only primaries")
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- After the CLIN-5853 indexer refactor, `esClient.refreshIndex(currentIndex)` fails when `df.saveToEs` writes nothing because the DataFrame is empty — the index never gets created via `es.index.auto.create`, so the refresh hits a missing index. Same risk applies to `forceMerge`, and to `createIndex` inside the `disableReplicas` branch.
- Guards the whole post-`setupIndex` sequence (write, replica toggling, refresh, force merge) behind `!df.isEmpty`. Empty df is now a true no-op on ES, matching pre-refactor behavior.

## Test plan
- [x] CI green
- [ ] Manual run against ES with an empty DataFrame (both `disableReplicas=true` and `disableReplicas=false`) — confirm no `index_not_found_exception`
- [ ] Manual run with a non-empty DataFrame — confirm write, refresh, and force merge still execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)