### PR TITLE
fix(DeltaLoader): UNIC-2007 Pass implicit spark instance to support parallel testing

### DIFF
--- a/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/loader/DeltaLoader.scala
+++ b/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/loader/DeltaLoader.scala
@@ -30,7 +30,7 @@ object DeltaLoader extends Loader {
 
     require(primaryKeys.forall(updates.columns.contains), s"requires column [${primaryKeys.mkString(", ")}]")
 
-    readTableAsDelta(location, databaseName, tableName)(spark) match {
+    readTableAsDelta(location, databaseName, tableName) match {
       case Failure(_) =>
         writeOnce(location, databaseName, tableName, updates, partitioning, format, options)
       case Success(existing) =>
@@ -85,7 +85,7 @@ object DeltaLoader extends Loader {
     require(updates.columns.exists(_.equals(createdOnName)), s"requires column [$createdOnName]")
     require(updates.columns.exists(_.equals(updatedOnName)), s"requires column [$updatedOnName]")
 
-    readTableAsDelta(location, databaseName, tableName)(spark) match {
+    readTableAsDelta(location, databaseName, tableName) match {
       case Failure(_) => writeOnce(location, databaseName, tableName, updates, partitioning, format, options)
       case Success(existing) =>
         val existingDf = existing.toDF
@@ -199,7 +199,7 @@ object DeltaLoader extends Loader {
       else
         newData
 
-    readTableAsDelta(location, databaseName, tableName)(spark) match {
+    readTableAsDelta(location, databaseName, tableName) match {
       case Failure(_) => writeOnce(location, databaseName, tableName, deduplicatedData, partitioning, format, options)
       case Success(existing) =>
         val existingDf = existing.toDF

--- a/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/loader/DeltaLoader.scala
+++ b/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/loader/DeltaLoader.scala
@@ -13,9 +13,9 @@ object DeltaLoader extends Loader {
 
   private def readTableAsDelta(location: String,
                                databaseName: String,
-                               tableName: String): Try[DeltaTable] = {
-    Try(DeltaTable.forName(s"$databaseName.$tableName"))
-      .orElse(Try(DeltaTable.forPath(location)))
+                               tableName: String)(implicit spark: SparkSession): Try[DeltaTable] = {
+    Try(DeltaTable.forName(spark, s"$databaseName.$tableName"))
+      .orElse(Try(DeltaTable.forPath(spark, location)))
   }
 
   override def upsert(location: String,
@@ -30,7 +30,7 @@ object DeltaLoader extends Loader {
 
     require(primaryKeys.forall(updates.columns.contains), s"requires column [${primaryKeys.mkString(", ")}]")
 
-    readTableAsDelta(location, databaseName, tableName) match {
+    readTableAsDelta(location, databaseName, tableName)(spark) match {
       case Failure(_) =>
         writeOnce(location, databaseName, tableName, updates, partitioning, format, options)
       case Success(existing) =>
@@ -85,7 +85,7 @@ object DeltaLoader extends Loader {
     require(updates.columns.exists(_.equals(createdOnName)), s"requires column [$createdOnName]")
     require(updates.columns.exists(_.equals(updatedOnName)), s"requires column [$updatedOnName]")
 
-    readTableAsDelta(location, databaseName, tableName) match {
+    readTableAsDelta(location, databaseName, tableName)(spark) match {
       case Failure(_) => writeOnce(location, databaseName, tableName, updates, partitioning, format, options)
       case Success(existing) =>
         val existingDf = existing.toDF
@@ -164,7 +164,7 @@ object DeltaLoader extends Loader {
                     databaseName: Option[String],
                     tableName: Option[String])(implicit spark: SparkSession): DataFrame = {
     Try(GenericLoader.read(location, format, readOptions, databaseName, tableName))
-      .getOrElse(DeltaTable.forPath(location).toDF)
+      .getOrElse(DeltaTable.forPath(spark, location).toDF)
   }
 
   def scd2(location: String,
@@ -199,7 +199,7 @@ object DeltaLoader extends Loader {
       else
         newData
 
-    readTableAsDelta(location, databaseName, tableName) match {
+    readTableAsDelta(location, databaseName, tableName)(spark) match {
       case Failure(_) => writeOnce(location, databaseName, tableName, deduplicatedData, partitioning, format, options)
       case Success(existing) =>
         val existingDf = existing.toDF

--- a/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/utils/DeltaUtils.scala
+++ b/datalake-spark3/src/main/scala/bio/ferlab/datalake/spark3/utils/DeltaUtils.scala
@@ -47,7 +47,7 @@ object DeltaUtils {
    * }}}
    */
   def compact(datasetConf: DatasetConf, partitionFilter: Option[String] = None)(implicit spark: SparkSession, conf: Configuration): Unit = {
-    val deltaTable = DeltaTable.forPath(datasetConf.location)
+    val deltaTable = DeltaTable.forPath(spark, datasetConf.location)
     partitionFilter match {
       case Some(pf) => deltaTable.optimize().where(pf).executeCompaction()
       case None => deltaTable.optimize().executeCompaction()
@@ -67,13 +67,13 @@ object DeltaUtils {
   def vacuum(datasetConf: DatasetConf, numberOfVersions: Int)(implicit spark: SparkSession, conf: Configuration): Unit = {
     import spark.implicits._
     val timestamps: Seq[Timestamp] = DeltaTable
-      .forPath(datasetConf.location)
+      .forPath(spark, datasetConf.location)
       .history(numberOfVersions)
       .select("timestamp")
       .as[Timestamp].collect().toSeq
     if (timestamps.size == numberOfVersions) {
       val retentionHours = Seq(336, getRetentionHours(timestamps)).max // 336 hours = 2 weeks
-      DeltaTable.forPath(datasetConf.location).vacuum(retentionHours)
+      DeltaTable.forPath(spark, datasetConf.location).vacuum(retentionHours)
     }
 
   }


### PR DESCRIPTION
Calling `forPath` and `forName` without explicitly giving the spark instance, as is done in `readTableAsDelta`, causes Spark to attempt to retrieve the active spark session for the current thread by calling `apache.spark.sql.getActiveSession()`. This functions relies on a private val which appears to be unset when the spark worker is transferred to another thread, causing `forPath/forName` to `throw DeltaErrors.activeSparkSessionNotFound()`. This then causes unwanted behaviour in all functions who use readTableAsDelta. 

Consequently, I explicitly passed the spark instance as an argument in all `forPath/forName` calls found in datalake-lib